### PR TITLE
fix: add issues:write permission to codex-review caller

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -3,6 +3,7 @@ name: Codex Code Review
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 on:
   pull_request_target:


### PR DESCRIPTION
## Summary

- Add `issues: write` to `codex-review.yml` caller permissions
- The reusable workflow's `post-review` job needs this to list/create/update PR comments via `github.rest.issues.*` API
- Without it, the workflow fails with `startup_failure` before any job runs

Fixes the Codex Code Review `startup_failure` seen on PRs #45, #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)